### PR TITLE
Add snapcraft config to easily build snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: wethr
+version: git
+summary: Command line weather tool.
+description: |
+
+grade: stable
+confinement: strict
+
+apps:
+  wethr:
+    command: wethr
+    plugs:
+      - network
+
+parts:
+  wethr:
+    plugin: nodejs
+    source: https://github.com/twobucks/wethr.git


### PR DESCRIPTION
This pull request adds the necessary yaml to make a snap of wethr. Snaps are universal software packages for Linux. See http://snapcraft.io/ for more details.

If accepted, you can go to http://build.snapcraft.io/ and hook it up to your master branch. Build will then create a snap on each commit to master and push to the edge channel in the snap store. At that point users can on supported Linux systems can ```snap install wethr --edge``` and will get updates whenever you push changes to master, automatically.

When you're happy with a release you can push it to the stable channel in the store. Once in the stable channel, users can just ```snap install wethr``` to get it and subsequent updates.