### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,23 @@
+name: wethr
+version: git
+summary: Command line weather tool.
+description: |
+  Get current weather:-
+    $ wethr
+  Get current weather in metric units
+    $ wethr --metric
+  Get current weather in imperial units
+    $ wethr --imperial
+grade: stable
+confinement: strict
+
+apps:
+  wethr:
+    command: wethr
+    plugs:
+      - network
+
+parts:
+  wethr:
+    plugin: nodejs
+    source: .


### PR DESCRIPTION
This pull request adds support to build wethr as a snap.

wethr is already [available](https://snapcraft.io/wethr/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/wethr) repo. 

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the wethr snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of wethr and push directly to the store. 

If accepted, I'm happy to walk you through the next steps. 